### PR TITLE
fixes https://github.com/hrbrmstr/rradar/issues/1

### DIFF
--- a/R/animate.R
+++ b/R/animate.R
@@ -18,6 +18,7 @@ animate_radar <- function(station = "GYX") {
   ir <- possibly(image_read, NULL)
 
   st_dir <- stations[stations$station == station,][["dir"]]
+  st_dir <- unique(st_dir)
 
   frames_dir_url <- sprintf("https://radar.weather.gov/ridge/RadarImg/%s/%s/", st_dir, station)
 


### PR DESCRIPTION
Fixes https://github.com/hrbrmstr/rradar/issues/1 with a unique.

This also shows that if you use this, then each station has only one `dir`
``` r
library(tidyverse)
library(rradar)
stations %>% 
  group_by(station) %>% 
  summarise(n_dir = length(unique(dir))) %>% 
  pull(n_dir) %>% 
  unique()
#> [1] 1
```

<sup>Created on 2019-12-05 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>

<details>

<summary>Session info</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ──────────────────────────────────────────────────────────
#>  setting  value                       
#>  version  R version 3.6.0 (2019-04-26)
#>  os       macOS Mojave 10.14.6        
#>  system   x86_64, darwin15.6.0        
#>  ui       X11                         
#>  language (EN)                        
#>  collate  en_US.UTF-8                 
#>  ctype    en_US.UTF-8                 
#>  tz       America/New_York            
#>  date     2019-12-05                  
#> 
#> ─ Packages ──────────────────────────────────────────────────────────────
#>  package     * version date       lib source                            
#>  assertthat    0.2.1   2019-03-21 [1] CRAN (R 3.6.0)                    
#>  backports     1.1.5   2019-10-02 [1] CRAN (R 3.6.0)                    
#>  broom         0.5.2   2019-04-07 [1] CRAN (R 3.6.0)                    
#>  cellranger    1.1.0   2016-07-27 [1] CRAN (R 3.6.0)                    
#>  cli           1.1.0   2019-03-19 [1] CRAN (R 3.6.0)                    
#>  colorspace    1.4-1   2019-03-18 [1] CRAN (R 3.6.0)                    
#>  crayon        1.3.4   2017-09-16 [1] CRAN (R 3.6.0)                    
#>  digest        0.6.23  2019-11-23 [1] CRAN (R 3.6.0)                    
#>  dplyr       * 0.8.3   2019-07-04 [1] CRAN (R 3.6.0)                    
#>  evaluate      0.14    2019-05-28 [1] CRAN (R 3.6.0)                    
#>  forcats     * 0.4.0   2019-02-17 [1] CRAN (R 3.6.0)                    
#>  generics      0.0.2   2018-11-29 [1] CRAN (R 3.6.0)                    
#>  ggplot2     * 3.2.1   2019-08-10 [1] CRAN (R 3.6.0)                    
#>  glue          1.3.1   2019-03-12 [1] CRAN (R 3.6.0)                    
#>  gtable        0.3.0   2019-03-25 [1] CRAN (R 3.6.0)                    
#>  haven         2.1.1   2019-07-04 [1] CRAN (R 3.6.0)                    
#>  highr         0.8     2019-03-20 [1] CRAN (R 3.6.0)                    
#>  hms           0.5.2   2019-10-30 [1] CRAN (R 3.6.0)                    
#>  htmltools     0.4.0   2019-10-04 [1] CRAN (R 3.6.0)                    
#>  httr          1.4.1   2019-08-05 [1] CRAN (R 3.6.0)                    
#>  jsonlite      1.6     2018-12-07 [1] CRAN (R 3.6.0)                    
#>  knitr         1.24.3  2019-08-28 [1] Github (muschellij2/knitr@abcea3d)
#>  lattice       0.20-38 2018-11-04 [1] CRAN (R 3.6.0)                    
#>  lazyeval      0.2.2   2019-03-15 [1] CRAN (R 3.6.0)                    
#>  lifecycle     0.1.0   2019-08-01 [1] CRAN (R 3.6.0)                    
#>  lubridate     1.7.4   2018-04-11 [1] CRAN (R 3.6.0)                    
#>  magick        2.2     2019-08-26 [1] CRAN (R 3.6.0)                    
#>  magrittr      1.5     2014-11-22 [1] CRAN (R 3.6.0)                    
#>  modelr        0.1.5   2019-08-08 [1] CRAN (R 3.6.0)                    
#>  munsell       0.5.0   2018-06-12 [1] CRAN (R 3.6.0)                    
#>  nlme          3.1-141 2019-08-01 [1] CRAN (R 3.6.0)                    
#>  pillar        1.4.2   2019-06-29 [1] CRAN (R 3.6.0)                    
#>  pkgconfig     2.0.3   2019-09-22 [1] CRAN (R 3.6.0)                    
#>  purrr       * 0.3.3   2019-10-18 [1] CRAN (R 3.6.0)                    
#>  R6            2.4.1   2019-11-12 [1] CRAN (R 3.6.0)                    
#>  Rcpp          1.0.3   2019-11-08 [1] CRAN (R 3.6.0)                    
#>  readr       * 1.3.1   2018-12-21 [1] CRAN (R 3.6.0)                    
#>  readxl        1.3.1   2019-03-13 [1] CRAN (R 3.6.0)                    
#>  rlang         0.4.2   2019-11-23 [1] CRAN (R 3.6.0)                    
#>  rmarkdown     1.16    2019-10-01 [1] CRAN (R 3.6.0)                    
#>  rradar      * 0.1.0   2019-12-05 [1] local                             
#>  rvest         0.3.4   2019-05-15 [1] CRAN (R 3.6.0)                    
#>  scales        1.1.0   2019-11-18 [1] CRAN (R 3.6.0)                    
#>  sessioninfo   1.1.1   2018-11-05 [1] CRAN (R 3.6.0)                    
#>  stringi       1.4.3   2019-03-12 [1] CRAN (R 3.6.0)                    
#>  stringr     * 1.4.0   2019-02-10 [1] CRAN (R 3.6.0)                    
#>  tibble      * 2.1.3   2019-06-06 [1] CRAN (R 3.6.0)                    
#>  tidyr       * 1.0.0   2019-09-11 [1] CRAN (R 3.6.0)                    
#>  tidyselect    0.2.5   2018-10-11 [1] CRAN (R 3.6.0)                    
#>  tidyverse   * 1.2.1   2017-11-14 [1] CRAN (R 3.6.0)                    
#>  vctrs         0.2.0   2019-07-05 [1] CRAN (R 3.6.0)                    
#>  withr         2.1.2   2018-03-15 [1] CRAN (R 3.6.0)                    
#>  xfun          0.11    2019-11-12 [1] CRAN (R 3.6.0)                    
#>  xml2          1.2.2   2019-08-09 [1] CRAN (R 3.6.0)                    
#>  yaml          2.2.0   2018-07-25 [1] CRAN (R 3.6.0)                    
#>  zeallot       0.1.0   2018-01-28 [1] CRAN (R 3.6.0)                    
#> 
#> [1] /Library/Frameworks/R.framework/Versions/3.6/Resources/library
```

</details>